### PR TITLE
Resolve i965_dri.so crash by not stripping mesa build IDs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,8 @@ parts:
     plugin: nil
     stage-packages:
     - libgl1-mesa-dri
+    build-attributes:
+    - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
     prime:
       - -lib/udev
       - -usr/doc


### PR DESCRIPTION
This appears to resolve the problem I've been working on for the last few days. You all should know what that is, but for posterity I'll summarize it here (with as many searchable keywords as I can think of):

* It started with mesa crashing. Specifically, there was a segfault and GDB would show `gbm_create_device()`, then two calls in `libgbm.so.1` then four calls in `i965_dri.so` (an intel mesa driver).
* To see what was going on, I tried to get debugging symbols for `i965_dri.so`. Because it was in a snap (and in retrospect, possibly because the elf was being modified), the only way I managed to do that was build all of mesa from source in debugging mode inside the snap (see https://github.com/wmww/egmde-snap/blob/176c8d0ce189ea1e76ae61d5147f0722e00f8d8f/snap/snapcraft.yaml#L75).
* With a debug build of mesa in hand, I got a more useful error: `assertion 'note && build_id_length(note) == 20' failed.` and was able to poke around where this happened.
* It turns out [`brw_disk_cache_init()`](https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/mesa/drivers/dri/i965/brw_disk_cache.c#L377) calls [`build_id_find_nhdr_for_addr()`](https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/mesa/drivers/dri/i965/brw_disk_cache.c#L390), which in turn uses [`dl_iterate_phdr()`](https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/util/build_id.c#L118) to look through all the dynamic libs currently open. When it finds the one it's in (`i965_dri.so`), it looks for a [GNU build ID section](https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/util/build_id.c#L83) in the .so (which is an elf file). If this elaborate process fails, null is returned and the program [crashes with a failed assertion](https://gitlab.freedesktop.org/mesa/mesa/blob/master/src/mesa/drivers/dri/i965/brw_disk_cache.c#L391) (note that the failed assertion message doesn't seem to be visible when not in debug mode). The purpose of this process remains mostly a mystery to me, but what it means is **mesa must have its build ID to function**.
* Snapcraft strips build IDs by default. Again, I don't know why.
* The way to tell if a *.so has a build ID, is to run `readelf --segments` on it. For example:
```
wmww:~$ readelf --segments /snap/egmde/current/usr/lib/x86_64-linux-gnu/dri/i965_dri.so 

Elf file type is DYN (Shared object file)
Entry point 0x69930
There are 7 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x000000000091c93d 0x000000000091c93d  R E    0x200000
  LOAD           0x000000000091d1a0 0x0000000000b1d1a0 0x0000000000b1d1a0
                 0x000000000006801c 0x000000000011a9c0  RW     0x200000
  DYNAMIC        0x0000000000979cc8 0x0000000000b79cc8 0x0000000000b79cc8
                 0x00000000000002a0 0x00000000000002a0  RW     0x8
  NOTE           0x00000000000001c8 0x00000000000001c8 0x00000000000001c8
                 0x0000000000000024 0x0000000000000024  R      0x4
  GNU_EH_FRAME   0x00000000008641a0 0x00000000008641a0 0x00000000008641a0
                 0x000000000001878c 0x000000000001878c  R      0x4
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
  GNU_RELRO      0x000000000091d1a0 0x0000000000b1d1a0 0x0000000000b1d1a0
                 0x000000000005ce60 0x000000000005ce60  R      0x1

 Section to Segment mapping:
  Segment Sections...
   00     .note.gnu.build-id .gnu.hash .dynsym .dynstr .gnu.version .gnu.version_r .rela.dyn .rela.plt .init .plt .plt.got .text .fini .rodata .eh_frame_hdr .eh_frame .gcc_except_table 
   01     .init_array .fini_array .data.rel.ro .dynamic .got .got.plt .data .bss 
   02     .dynamic 
   03     .note.gnu.build-id 
   04     .eh_frame_hdr 
   05     
   06     .init_array .fini_array .data.rel.ro .dynamic .got 
```
The key thing to "note" (pun intended) is the `.note.gnu.build-id` at the start of `Section to Segment mapping`. That tells you there's a build ID. If that's not there (for example if that line starts with `.dynsym` instead) then the there is no build ID and mesa probably wont work.
* The change I make causes snapcraft to stop stripping build IDs, and everything to work (at least on my machine).