### PR TITLE
If Xwayland is available activate the Xwayland support

### DIFF
--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -4,20 +4,15 @@ set -e
 # For a classic snap this needs to be something sane
 export XDG_RUNTIME_DIR=/run/user/$(id -u)
 
-if x11_display=$(snapctl get x11-display); then
-  if [ -n "${x11_display}" ]; then
-    if [ "${x11_display}" == "auto" ]; then
-      x11_display=0
+if which Xwayland > /dev/null
+then
+  x11_display=0
 
-      while [ -e "/tmp/.X11-unix/X${x11_display}" ]; do
-        let x11_display+=1
-      done
-    fi
-    if [ ${x11_display} -eq ${x11_display} 2>/dev/null ]; then
-      export MIR_SERVER_X11_DISPLAY_EXPERIMENTAL=${x11_display}
-      export MIR_X11_LAZY=on
-    fi
-  fi
+  while [ -e "/tmp/.X11-unix/X${x11_display}" ]; do
+    let x11_display+=1
+  done
+
+  export MIR_SERVER_X11_DISPLAY_EXPERIMENTAL=${x11_display}
 fi
 
 if [ "$(lsb_release -c -s)" == "xenial" ]


### PR DESCRIPTION
If Xwayland is available activate the Xwayland support.

While still "experimental", it no longer causes problems to have X11 support activate.