### PR TITLE
Don't try to use dnf

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,6 +6,6 @@ cp $SNAP/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
 # Ensure Wayland support is available for Qt apps
 if [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "ubuntu" ]; then
   apt --assume-yes install qtwayland5
-elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
-  dnf --assumeyes  install qt5-qtwayland
+#elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
+#  dnf --assumeyes  install qt5-qtwayland
 fi


### PR DESCRIPTION
Don't try to use dnf in the install hook on Fedora.

It fails and so the install fails on rawhide.