### PR TITLE
Drop the snap's LD_LIBRARY_PATH when running dnf

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p /usr/share/wayland-sessions/
 cp $SNAP/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,8 +4,10 @@ mkdir -p /usr/share/wayland-sessions/
 cp $SNAP/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
 
 # Ensure Wayland support is available for Qt apps
-if [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "ubuntu" ]; then
+if which apt > /dev/null 2>&1
+then
   apt --assume-yes install qtwayland5
-elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
-  env -u LD_LIBRARY_PATH dnf --assumeyes  install qt5-qtwayland
+elif which dnf > /dev/null 2>&1
+then
+  env -u LD_LIBRARY_PATH dnf --assumeyes install qt5-qtwayland
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -6,6 +6,6 @@ cp $SNAP/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
 # Ensure Wayland support is available for Qt apps
 if [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "ubuntu" ]; then
   apt --assume-yes install qtwayland5
-#elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
-#  dnf --assumeyes  install qt5-qtwayland
+elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
+  env -u LD_LIBRARY_PATH dnf --assumeyes  install qt5-qtwayland
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,11 +1,13 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p /usr/share/wayland-sessions/
 cp $SNAP/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
 
 # Ensure Wayland support is available for Qt apps
-if [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "ubuntu" ]; then
+if which apt > /dev/null 2>&1
+then
   apt --assume-yes install qtwayland5
-elif [ "$(sed -Ene 's/^ID=(.*)/\1/p' /etc/os-release)" = "fedora" ]; then
-  dnf --assumeyes  install qt5-qtwayland
+elif which dnf > /dev/null 2>&1
+then
+  env -u LD_LIBRARY_PATH dnf --assumeyes install qt5-qtwayland
 fi


### PR DESCRIPTION
Drop the snap's LD_LIBRARY_PATH when running dnf in the install hook on Fedora.

It only leads to confusion.