### PR TITLE
Use Mir-on-X when run on a Wayland desktop 

### DIFF
--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -8,7 +8,7 @@ export XDG_RUNTIME_DIR=/run/user/$(id -u)
 if [ -n "$WAYLAND_DISPLAY" ] && [ -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]
 then
   # select an uncontested WAYLAND_DISPLAY
-  display=10
+  display=0
   while [ -e "${XDG_RUNTIME_DIR}/wayland-${display}" ]; do
       let display+=1
   done

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -4,10 +4,15 @@ set -e
 # For a classic snap this needs to be something sane
 export XDG_RUNTIME_DIR=/run/user/$(id -u)
 
-# If there's another Wayland server, ignore WAYLAND_DISPLAY
-if [ -n "$WAYLAND_DISPLAY" ] && [ -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY.lock" ]
+# If there's an existing Wayland server, we're likely on a Wayland desktop
+if [ -n "$WAYLAND_DISPLAY" ] && [ -e "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]
 then
-  unset WAYLAND_DISPLAY
+  # select an uncontested WAYLAND_DISPLAY
+  display=10
+  while [ -e "${XDG_RUNTIME_DIR}/wayland-${display}" ]; do
+      let display+=1
+  done
+  WAYLAND_DISPLAY=wayland-${display}
 fi
 
 if [ "$(sed -Ene 's/^VERSION_CODENAME=(.*)/\1/p' /etc/os-release)" == "xenial" ]


### PR DESCRIPTION
Use Mir-on-X when run on a Wayland desktop.

When WAYLAND_DISPLAY=wayland-0 (typical of a Wayland desktop) the previous approach of unsetting WAYLAND_DISPLAY and letting Mir select the socket meant that Mir-on-Wayland could connect to the existing server. While that "works" the host desktop intercepts inputs needed for egmde (e.g. Alt-Tab) expected by egmde and the experience is sub-optimal.