### PR TITLE
Add libtinfo5 to mesa stage.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,6 +83,7 @@ parts:
     plugin: nil
     stage-packages:
     - libgl1-mesa-dri
+    - libtinfo5
     build-attributes:
     - no-patchelf # Otherwise snapcraft may strip the build ID and cause the driver to crash
     prime:


### PR DESCRIPTION
For some reason snapcraft wasn't picking up this transitive dependency. Fixes egmde on my laptop (and probably everywhere else that's using a gallium [ie: non-i965] driver?)

Closes: #28