### PR TITLE
Fix  library path

### DIFF
--- a/glue/Xwayland.launcher
+++ b/glue/Xwayland.launcher
@@ -1,0 +1,6 @@
+#!/snap/egmde/current/bin/sh
+set -e
+unset LD_LIBRARY_PATH
+unset __EGL_VENDOR_LIBRARY_DIRS
+unset LIBGL_DRIVERS_PATH
+exec Xwayland "$@"

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-LD_LIBRARY_PATH=${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}
 
 # For a classic snap this needs to be something sane
 XDG_RUNTIME_DIR=/run/user/$(id -u)
@@ -36,6 +35,11 @@ then
   else
     echo wallpaper-bottom=0x92006a >> "$config_file"
   fi
+fi
+
+if ! which Xwayland &> /dev/null
+then
+  unset MIR_SERVER_ENABLE_X11
 fi
 
 # Run server

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -39,4 +39,5 @@ then
 fi
 
 # Run server
+export LD_LIBRARY_PATH=${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}:${SNAP}/lib/${SNAPCRAFT_ARCH_TRIPLET}
 exec "$SNAP/usr/local/bin/egmde" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@ apps:
     environment:
       # Prep for Mir
       MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform
-      MIR_SERVER_XWAYLAND_PATH: ${SNAP}/usr/bin/Xwayland
+      MIR_SERVER_XWAYLAND_PATH: ${SNAP}/bin/Xwayland.launcher
       MIR_SERVER_APP_ENV: "GDK_BACKEND=wayland,x11:QT_QPA_PLATFORM=wayland:SDL_VIDEODRIVER=wayland:-QT_QPA_PLATFORMTHEME:NO_AT_BRIDGE=1:QT_ACCESSIBILITY:QT_LINUX_ACCESSIBILITY_ALWAYS_ON:_JAVA_AWT_WM_NONREPARENTING=1:-GTK_MODULES:-OOO_FORCE_DESKTOP:-GNOME_ACCESSIBILITY:-LD_LIBRARY_PATH:-__EGL_VENDOR_LIBRARY_DIRS:-LIBGL_DRIVERS_PATH"
       MIR_SERVER_ENABLE_X11: 1
       __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
@@ -92,6 +92,7 @@ parts:
     organize:
       egmde.launcher: bin/
       egmde.desktop: bin/
+      Xwayland.launcher: bin/
     override-build: |
       snapcraftctl build
       sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.launcher
@@ -119,13 +120,7 @@ parts:
       - -usr/share/man
       - -usr/share/pkgconfig
 
-  xwayland:
+  sh:
     plugin: nil
-    build-attributes:
-      - no-patchelf
     stage-packages:
-      - xwayland
-      - libbz2-1.0
-      - libbsd0
-      - libgcrypt20
-      - libffi7
+      - dash

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,10 +17,10 @@ apps:
       # Prep for Mir
       MIR_SERVER_PLATFORM_PATH: ${SNAP}/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform
       MIR_SERVER_XWAYLAND_PATH: ${SNAP}/usr/bin/Xwayland
+      MIR_SERVER_APP_ENV: "GDK_BACKEND=wayland,x11:QT_QPA_PLATFORM=wayland:SDL_VIDEODRIVER=wayland:-QT_QPA_PLATFORMTHEME:NO_AT_BRIDGE=1:QT_ACCESSIBILITY:QT_LINUX_ACCESSIBILITY_ALWAYS_ON:_JAVA_AWT_WM_NONREPARENTING=1:-GTK_MODULES:-OOO_FORCE_DESKTOP:-GNOME_ACCESSIBILITY:-LD_LIBRARY_PATH:-__EGL_VENDOR_LIBRARY_DIRS:-LIBGL_DRIVERS_PATH"
       MIR_SERVER_ENABLE_X11: 1
       __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
-      EGMDE_LAUNCH_PREFIX: "env -u LD_LIBRARY_PATH -u __EGL_VENDOR_LIBRARY_DIRS -u LIBGL_DRIVERS_PATH -u EGMDE_LAUNCH_PREFIX --"
       PATH: ${PATH}:/snap/bin
       XDG_DATA_DIRS: ${XDG_DATA_DIRS}:~/.local/share
       XDG_CURRENT_DESKTOP: egmde
@@ -126,3 +126,6 @@ parts:
     stage-packages:
       - xwayland
       - libbz2-1.0
+      - libbsd0
+      - libgcrypt20
+      - libffi7

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,6 +92,9 @@ parts:
     organize:
       egmde.launcher: bin/
       egmde.desktop: bin/
+    override-build: |
+      snapcraftctl build
+      sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.launcher
 
   mesa:
     plugin: nil


### PR DESCRIPTION
Fixes: #36

With `base: core20` we apparently run the host shell binaries.

That means we can't use LD_LIBRARY_PATH in the global environment as those shells then crash.

We have to set LD_LIBRARY_PATH for running egmde, otherwise it will crash.

But we must unset LD_LIBRARY_PATH for running any apps we launch and for Xwayland if installed on the host. 