### PR TITLE
New `egmde.remote` command

### DIFF
--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -1,7 +1,7 @@
 #!/snap/egmde/current/bin/sh
-set -e
+set -ex
 unset LD_LIBRARY_PATH
 unset __EGL_VENDOR_LIBRARY_DIRS
 unset LIBGL_DRIVERS_PATH
 export MIR_SERVER_PLATFORM_GRAPHICS_LIB=$(find "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform" -name server-x11.so.*)
-exec sh -lc egmde "$@"
+exec sh -lc "egmde $@"

--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -1,0 +1,7 @@
+#!/snap/egmde/current/bin/sh
+set -e
+unset LD_LIBRARY_PATH
+unset __EGL_VENDOR_LIBRARY_DIRS
+unset LIBGL_DRIVERS_PATH
+export MIR_SERVER_PLATFORM_GRAPHICS_LIB=$(find "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/mir/server-platform" -name server-x11.so.*)
+exec sh -lc egmde "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,9 @@ apps:
       XDG_DATA_DIRS: ${XDG_DATA_DIRS}:~/.local/share
       XDG_CURRENT_DESKTOP: egmde
 
+  remote:
+    command: bin/egmde.remote
+
 parts:
   recipe-version:
     plugin: nil
@@ -92,10 +95,12 @@ parts:
     organize:
       egmde.launcher: bin/
       egmde.desktop: bin/
+      egmde.remote: bin/
       Xwayland.launcher: bin/
     override-build: |
       snapcraftctl build
       sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.launcher
+      sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.remote
 
   mesa:
     plugin: nil


### PR DESCRIPTION
New `egmde.remote` command to run egmde on a remote X11 server.

For example:
```bash
ssh -XC Octopull-X1C3 egmde.remote
```
(Replace Octopull-X1C3 with your own remote system)