### PR TITLE
Adds waybar and swaybg

### DIFF
--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -44,7 +44,7 @@ if [[ ! -e "$qtwayland_check" ]]; then
 fi
 
 if ! grep -q "^[# ]*shell-components=" ~/.config/egmde.config; then
-  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/usr/bin/waybar" >> "$config_file"
+  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/bin/waybar.launcher" >> "$config_file"
 fi
 
 if [[ ! -e "~/.config/waybar/config" ]]

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -40,6 +40,7 @@ if [[ ! -e "$qtwayland_check" ]]; then
       echo "app-env-amend=QT_QPA_PLATFORM=xcb" >> "$config_file"
     fi
   fi
+  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher" >> "$config_file"
   touch "$qtwayland_check"
 fi
 

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -40,8 +40,197 @@ if [[ ! -e "$qtwayland_check" ]]; then
       echo "app-env-amend=QT_QPA_PLATFORM=xcb" >> "$config_file"
     fi
   fi
-  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher" >> "$config_file"
+  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/usr/bin/waybar" >> "$config_file"
   touch "$qtwayland_check"
+fi
+
+if [[ ! -e "~/.config/waybar/config" ]]
+then
+  mkdir -p ~/.config/waybar
+  cat > ~/.config/waybar/config <<EOF
+{
+    "layer": "bottom", // Waybar at top layer
+    "height": 30, // Waybar height (to be removed for auto height)
+    "modules-left": ["network"],
+    "modules-center": ["clock"],
+    "modules-right": ["cpu", "memory", "temperature", "battery"],
+    "tray": {
+        // "icon-size": 21,
+        "spacing": 10
+    },
+    "clock": {
+        "format": "{:%y-%m-%d %H:%M}",
+        "tooltip-format": "{:%y-%m-%d | %H:%M}",
+        "format-alt": "{:%H:%M}"
+    },
+    "cpu": {
+        "format": "CPU: {usage}%",
+        "tooltip": false
+    },
+    "memory": {
+        "format": "Mem: {}%"
+    },
+    "temperature": {
+        // "thermal-zone": 2,
+        // "hwmon-path": "/sys/class/hwmon/hwmon2/temp1_input",
+        "critical-threshold": 80,
+        // "format-critical": "{temperatureC}°C {icon}",
+        "format": "{temperatureC}°C",
+        "format-icons": ["", "", ""]
+    },
+    "battery": {
+        "states": {
+            // "good": 95,
+            "warning": 30,
+            "critical": 15
+        },
+        "format-alt": "{capacity}% {icon}",
+        "format-charging": "{capacity}% ",
+        "format-plugged": "{capacity}% ",
+        "format": "{time} ({capacity}%)",
+        // "format-good": "", // An empty format will hide the module
+        // "format-full": "",
+        "format-icons": ["", "", "", "", ""]
+    },
+    "network": {
+        // "interface": "wlp2*", // (Optional) To force the use of this interface
+        "format-wifi": "{essid} ({signalStrength}%)",
+        "format-ethernet": "{ifname}: {ipaddr}/{cidr} ",
+        "format-linked": "{ifname} (No IP) ",
+        "format-disconnected": "Disconnected ⚠",
+        "format-alt": "{ifname}: {ipaddr}/{cidr}"
+    }
+}
+EOF
+fi
+
+if [[ ! -e "~/.config/waybar/style.css" ]]
+then
+  mkdir -p ~/.config/waybar
+  cat > ~/.config/waybar/style.css <<EOF
+* {
+    border: none;
+    border-radius: 0;
+    /* `otf-font-awesome` is required to be installed for icons */
+    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    min-height: 0;
+}
+
+window#waybar {
+    /*background-color: rgba(43, 48, 59, 0.5);
+    border-bottom: 3px solid rgba(100, 114, 125, 0.5);*/
+    background-color: rgba(146, 0, 106, 0.3);
+    border-bottom: 3px solid rgba(73, 0, 53, 0.3);
+    color: #ffffff;
+    transition-property: background-color;
+    transition-duration: .5s;
+}
+
+window#waybar.hidden {
+    opacity: 0.2;
+}
+
+window#waybar.termite {
+    background-color: #3F3F3F;
+}
+
+window#waybar.chromium {
+    background-color: #000000;
+    border: none;
+}
+
+#mode {
+    background-color: #64727D;
+    border-bottom: 3px solid #ffffff;
+}
+
+#clock,
+#battery,
+#cpu,
+#memory,
+#temperature,
+#backlight,
+#network,
+#pulseaudio,
+#custom-media,
+#tray,
+#mode,
+#idle_inhibitor,
+#mpd {
+    padding: 0 10px;
+    margin: 0 4px;
+    color: #ffffff;
+}
+
+#clock {
+    background-color: #64727D;
+}
+
+#battery {
+    background-color: #ffffff;
+    color: #000000;
+}
+
+#battery.charging {
+    color: #ffffff;
+    background-color: #26A65B;
+}
+
+@keyframes blink {
+    to {
+        background-color: #ffffff;
+        color: #000000;
+    }
+}
+
+#battery.critical:not(.charging) {
+    background-color: #f53c3c;
+    color: #ffffff;
+    animation-name: blink;
+    animation-duration: 0.5s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
+}
+
+label:focus {
+    background-color: #000000;
+}
+
+#cpu {
+    background-color: #2ecc71;
+    color: #000000;
+}
+
+#memory {
+    background-color: #9b59b6;
+}
+
+#backlight {
+    background-color: #90b1b1;
+}
+
+#network {
+    background-color: #2980b9;
+}
+
+#network.disconnected {
+    background-color: #f53c3c;
+}
+
+#temperature {
+    background-color: #f0932b;
+}
+
+#temperature.critical {
+    background-color: #eb4d4b;
+}
+
+#tray {
+    background-color: #2980b9;
+}
+EOF
 fi
 
 # Run server

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -40,8 +40,11 @@ if [[ ! -e "$qtwayland_check" ]]; then
       echo "app-env-amend=QT_QPA_PLATFORM=xcb" >> "$config_file"
     fi
   fi
-  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/usr/bin/waybar" >> "$config_file"
   touch "$qtwayland_check"
+fi
+
+if ! grep -q "^[# ]*shell-components=" ~/.config/egmde.config; then
+  echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/usr/bin/waybar" >> "$config_file"
 fi
 
 if [[ ! -e "~/.config/waybar/config" ]]

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -111,7 +111,7 @@ then
 * {
     border: none;
     border-radius: 0;
-    /* `otf-font-awesome` is required to be installed for icons */
+    /* 'otf-font-awesome' is required to be installed for icons */
     font-family: Roboto, Helvetica, Arial, sans-serif;
     font-size: 13px;
     min-height: 0;

--- a/glue/egmde.launcher
+++ b/glue/egmde.launcher
@@ -47,10 +47,10 @@ if ! grep -q "^[# ]*shell-components=" ~/.config/egmde.config; then
   echo "shell-components=/snap/egmde/current/bin/swaybg.launcher:/snap/egmde/current/bin/waybar.launcher" >> "$config_file"
 fi
 
-if [[ ! -e "~/.config/waybar/config" ]]
+if [[ ! -e "$config_dir/waybar/config" ]]
 then
-  mkdir -p ~/.config/waybar
-  cat > ~/.config/waybar/config <<EOF
+  mkdir -p $config_dir/waybar
+  cat > $config_dir/waybar/config <<EOF
 {
     "layer": "bottom", // Waybar at top layer
     "height": 30, // Waybar height (to be removed for auto height)
@@ -107,15 +107,15 @@ then
 EOF
 fi
 
-if [[ ! -e "~/.config/waybar/style.css" ]]
+if [[ ! -e "$config_dir/waybar/style.css" ]]
 then
-  mkdir -p ~/.config/waybar
-  cat > ~/.config/waybar/style.css <<EOF
+  mkdir -p $config_dir/waybar
+  cat > $config_dir/waybar/style.css <<EOF
 * {
     border: none;
     border-radius: 0;
     /* 'otf-font-awesome' is required to be installed for icons */
-    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-family: Ubuntu, FreeSans, Arial, sans-serif;
     font-size: 13px;
     min-height: 0;
 }

--- a/glue/swaybg.launcher
+++ b/glue/swaybg.launcher
@@ -3,5 +3,7 @@ set -e
 
 background=$(snapctl get background)
 if [ -e "${background}" ]; then
-  exec ${SNAP}/usr/bin/swaybg -i "${background}"
+  export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/gdk-pixbuf-2.0/2.10.0/loaders"
+  export GDK_PIXBUF_MODULE_FILE="$SNAP_COMMON/loaders.cache"
+  GDK_BACKEND=wayland exec ${SNAP}/usr/bin/swaybg -i "${background}"
 fi

--- a/glue/swaybg.launcher
+++ b/glue/swaybg.launcher
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+background=$(snapctl get background)
+if [ -e "${background}" ]; then
+  exec ${SNAP}/usr/bin/swaybg -i "${background}"
+fi

--- a/glue/waybar.launcher
+++ b/glue/waybar.launcher
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+GDK_BACKEND=wayland exec ${SNAP}/usr/bin/waybar

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,3 +2,12 @@
 
 mkdir -p /usr/share/wayland-sessions/
 cp "$SNAP"/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
+
+for x in "x86_64-linux-gnu" "aarch64-linux-gnu" "arm-linux-gnueabihf";
+do
+  if [ -e "$SNAP/usr/lib/$x" ]; then ARCH_TRIPLET="$x"; fi
+done
+
+export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/${ARCH_TRIPLET}/gdk-pixbuf-2.0/2.10.0/loaders"
+export GDK_PIXBUF_MODULE_FILE="$SNAP_COMMON/loaders.cache"
+$SNAP/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -2,3 +2,12 @@
 
 mkdir -p /usr/share/wayland-sessions/
 cp "$SNAP"/bin/egmde.desktop /usr/share/wayland-sessions/egmde.desktop
+
+for x in "x86_64-linux-gnu" "aarch64-linux-gnu" "arm-linux-gnueabihf";
+do
+  if [ -e "$SNAP/usr/lib/$x" ]; then ARCH_TRIPLET="$x"; fi
+done
+
+export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/${ARCH_TRIPLET}/gdk-pixbuf-2.0/2.10.0/loaders"
+export GDK_PIXBUF_MODULE_FILE="$SNAP_COMMON/loaders.cache"
+$SNAP/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders > $GDK_PIXBUF_MODULE_FILE

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,7 +95,7 @@ parts:
       swaybg.launcher: bin/
     override-build: |
       snapcraftctl build
-      sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.launcher
+      sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/swaybg.launcher
 
   mesa-patchelf:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,6 +92,7 @@ parts:
     organize:
       egmde.launcher: bin/
       egmde.desktop: bin/
+      swaybg.launcher: bin/
     override-build: |
       snapcraftctl build
       sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/egmde.launcher
@@ -102,6 +103,7 @@ parts:
     - libgl1-mesa-dri
     - libtinfo5
     - xwayland # included in this part because it tries to pull in mesa bits
+    - swaybg
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
       - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,7 @@ parts:
       egmde.launcher: bin/
       egmde.desktop: bin/
       swaybg.launcher: bin/
+      waybar.launcher: bin/
     override-build: |
       snapcraftctl build
       sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/swaybg.launcher

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,8 +102,10 @@ parts:
     stage-packages:
     - libgl1-mesa-dri
     - libtinfo5
-    - xwayland # included in this part because it tries to pull in mesa bits
+    # included in this part because it tries to pull in mesa bits
+    - xwayland
     - swaybg
+    - waybar
     stage:
       # The libraries in .../dri need no-patchelf, so they come from the mesa-unpatched part
       - -usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri


### PR DESCRIPTION
Adds waybar and swaybg to the snap.

Waybar is configured and runs by default. It can be a bit strange about fonts, but the options here seem OK on Xenial, Bionic and Focal. (Not yet tested on any non-Ubuntu distros.)

Swaybg doesn't run unless the "background" configuration setting points to a real file. E.g. for the default Ubuntu background:

`snap set egmde background=/usr/share/backgrounds/warty-final-ubuntu.png`