### PR TITLE
egmde.remote: a handy launch script for using egmde over VNC

### DIFF
--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -18,8 +18,9 @@ fi
 ssh -T -L ${EGMDE_REMOTE_LOCALPORT:-5900}:localhost:${EGMDE_REMOTE_RFBPORT:-5900} "$@" -- bash -el <<EOT
 if command -v x11vnc &> /dev/null && command -v Xvfb &> /dev/null && command -v egmde.login &> /dev/null
 then
-  x11vnc -create -localhost -rfbport ${EGMDE_REMOTE_RFBPORT:-5900} -cursor none -env FD_PROG=egmde.login -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028}\
-   -env MIR_SERVER_X11_OUTPUT=${EGMDE_REMOTE_OUTPUT:-1280x1028} -gone 'killall Xvfb'
+  x11vnc -create -localhost -rfbport ${EGMDE_REMOTE_RFBPORT:-5900} -cursor none -env FD_PROG=\`which egmde.login\`\
+    -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028} -env MIR_SERVER_X11_OUTPUT=${EGMDE_REMOTE_OUTPUT:-1280x1028}\
+    -env X11VNC_SKIP_DISPLAY=0-20 -gone 'killall Xvfb'
 else
   echo "ERROR: x11vnc, Xvfb and/or egmde could not be found on the remote"
   echo "To set these up, try, for example:"

--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+
+if [ $# -lt 1 -o "$1" == "--help" -o "$1" == "-h" ]
+then
+  echo "$(basename $0) - Handy launch script for using egmde over VNC"
+  echo "  This sets up ssh tunnelling and a remote VNC server, once the"
+  echo "  server is running it can be connected to locally with any VNC"
+  echo "  client (e.g. 'gvncviewer localhost')"
+  echo "Usage: $(basename $0) [ssh-login]"
+  echo "[ssh-login] login for ssh: hostname, user@hostname or -p port user@ipaddress"
+  echo "The desktop size can be set with EGMDE_REMOTE_OUTPUT=WxH $(basename $0) [login]"
+  exit
+fi
+
+ssh -T -L 5900:localhost:5900 $* -- bash -el <<EOT
+if command -v x11vnc &> /dev/null && command -v Xvfb &> /dev/null && command -v egmde.login &> /dev/null
+then
+  x11vnc -create -localhost -cursor none -env FD_PROG=egmde.login -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028}\
+   -env MIR_SERVER_X11_OUTPUT=${EGMDE_REMOTE_OUTPUT:-1280x1028} -gone 'killall Xvfb'
+else
+  echo "ERROR: x11vnc, Xvfb and/or egmde could not be found on the remote"
+  echo "To set these up, try, for example:"
+  echo "  ssh $*"
+  echo "  sudo apt install x11vnc xvfb"
+  echo "  sudo snap install egmde"
+  echo "  exit"
+  exit
+fi
+EOT

--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -8,14 +8,17 @@ then
   echo "  client (e.g. 'gvncviewer localhost')"
   echo "Usage: $(basename $0) [ssh-login]"
   echo "[ssh-login] login for ssh: hostname, user@hostname or -p port user@ipaddress"
-  echo "The desktop size can be set with EGMDE_REMOTE_OUTPUT=WxH $(basename $0) [login]"
+  echo "  o The desktop size can be set with EGMDE_REMOTE_OUTPUT=WxH $(basename $0) [login]"
+  echo "  o The port on the host system can be set with EGMDE_REMOTE_RFBPORT=59xx ..."
+  echo "  o The port on the client system can be set with EGMDE_REMOTE_LOCALPORT=59yy ..."
+  echo "    If connecting with EGMDE_REMOTE_LOCALPORT=59yy use gvncviewer localhost:yy"
   exit
 fi
 
-ssh -T -L 5900:localhost:5900 "$@" -- bash -el <<EOT
+ssh -T -L ${EGMDE_REMOTE_LOCALPORT:-5900}:localhost:${EGMDE_REMOTE_RFBPORT:-5900} "$@" -- bash -el <<EOT
 if command -v x11vnc &> /dev/null && command -v Xvfb &> /dev/null && command -v egmde.login &> /dev/null
 then
-  x11vnc -create -localhost -cursor none -env FD_PROG=egmde.login -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028}\
+  x11vnc -create -localhost -rfbport ${EGMDE_REMOTE_RFBPORT:-5900} -cursor none -env FD_PROG=egmde.login -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028}\
    -env MIR_SERVER_X11_OUTPUT=${EGMDE_REMOTE_OUTPUT:-1280x1028} -gone 'killall Xvfb'
 else
   echo "ERROR: x11vnc, Xvfb and/or egmde could not be found on the remote"

--- a/glue/egmde.remote
+++ b/glue/egmde.remote
@@ -12,7 +12,7 @@ then
   exit
 fi
 
-ssh -T -L 5900:localhost:5900 $* -- bash -el <<EOT
+ssh -T -L 5900:localhost:5900 "$@" -- bash -el <<EOT
 if command -v x11vnc &> /dev/null && command -v Xvfb &> /dev/null && command -v egmde.login &> /dev/null
 then
   x11vnc -create -localhost -cursor none -env FD_PROG=egmde.login -env FD_GEOM=${EGMDE_REMOTE_OUTPUT:-1280x1028}\

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,9 @@ apps:
   login:
     command: bin/egmde-session
 
+  remote:
+    command: bin/egmde.remote
+
 parts:
   recipe-version:
     plugin: nil
@@ -90,6 +93,7 @@ parts:
       egmde.desktop: bin/
       swaybg.launcher: bin/
       waybar.launcher: bin/
+      egmde.remote: bin/
     override-build: |
       snapcraftctl build
       sed s/\$\{SNAPCRAFT_ARCH_TRIPLET}/${SNAPCRAFT_ARCH_TRIPLET}/g --in-place $SNAPCRAFT_PART_INSTALL/swaybg.launcher


### PR DESCRIPTION
This sets up ssh tunnelling and a remote VNC server, once the  server is running it can be connected to locally with any VNC  client (e.g. `gvncviewer localhost`)
